### PR TITLE
Automatically switch node versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.1
+- Add the ability to automatically switch node versions based on the project's...
+  - `.node-version` file
+  - `.nvmrc` file
+  - `engines.node` field in `package.json`

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -1,0 +1,26 @@
+########################### HELPER FUNCTIONS ###########################
+# Automatically set the Node version based on:
+# 1. The .node-version file in the current directory
+# 2. The .nvmrc file in the current directory
+# 3. The engines.node field in the package.json file in the current directory
+auto_node_version() {
+  local node_version
+  if [ -f .node-version ]; then
+    node_version=$(cat .node-version)
+  elif [ -f .nvmrc ]; then
+    node_version=$(cat .nvmrc)
+  elif [ -f package.json ]; then
+    node_version=$(jq -r '.engines.node' package.json)
+  fi
+  if [ -n "$node_version" ]; then
+    nvm use "$node_version"
+  fi
+}
+
+########################### ZSH HOOKS ###########################
+autoload -U add-zsh-hook
+load-node-version-from-package-json() {
+  auto_node_version
+}
+add-zsh-hook chpwd load-node-version-from-package-json
+load-node-version-from-package-json


### PR DESCRIPTION
Automatically set the Node version based on:

1. The .node-version file in the current directory
2. The .nvmrc file in the current directory
3. The engines.node field in the package.json file in the current directory

---

## How to Test
1. Add a `.node-version` file with the value of `20`.
2. Add the `.nvmrc` file with the value of `18`.
3. Add an `engines.node` section to your `package.json` file with a value of `16`. 
4. Run `auto_node_version`

- [x] Verify that the version of Node switches to `20`.

5. Remove the `.node-version` file and run `auto_node_version` again.

- [x] Verify that the version of Node switches to `18`.

6. Remove the `.nvmrc` file and run` auto_node_version` again.

- [x] Verify that the version of Node switches to `16`.