### PR TITLE
Add the sayresult success phrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.0
+- Add the sayresult helper function.
+
 ## 0.3.0
 - Add helper scripts to streamline git commands.
   - `gl` - Git log with pretty formatting.

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -98,6 +98,26 @@ autoup_setup() {
     fi
 }
 
+# Speak a random success phrase when your script completes
+sayresult() {
+    # Array of success phrases
+    phrases=(
+        "Porque es muy rapido"
+        "Task complete"
+        "Done!"
+        "Yep."
+        "Red leader standing by..."
+        "Cheers!"
+        "Pwn the noobs"
+    )
+
+    # Calculate random index based on the number of phrases
+    random_index=$(($RANDOM % ${#phrases[@]}))
+
+    # Speak a random success phrase
+    say -v Samantha "${phrases[$random_index]}" || say -v "Epic fail!"
+}
+
 ########################### ZSH HOOKS ###########################
 autoload -U add-zsh-hook
 load-node-version-from-package-json() {


### PR DESCRIPTION
## Changelog
- Add the sayresult helper function.

---

## How to Test
1. In a repo with a `package.json` file, run `yarn install && sayresult`

 - [x] Verify that the script audibly speaks one of the success phrases, notifying you when the process completes. 