### PR TITLE
Add scripts specific to Dow Jones processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.0
+- Add scripts specific to the Dow Jones build process
+  - `djbuild` - Build a DJ Plugin or Theme
+  - `djxbuild` - Rebuild a DJ Plugin or Theme
+  - `djcob` - Check out a branch and build it
+  - `djcoxb` - Check out a branch and run a full rebuild
+- Add the Nuke scripts
+  - `nukejs` - Remove lock files and `node_modules`.
+  - `nukephp` - Remove lock files and `vendor`.
+
 ## 0.4.0
 - Add the sayresult helper function.
 

--- a/zshrc-dj.sh
+++ b/zshrc-dj.sh
@@ -1,0 +1,50 @@
+# Build process for NewsPress themes and plugins
+djbuild() {
+  echo "composer install"
+  composer install
+
+  # Check if package.json is present
+  if [[ ! -f package.json ]]; then
+    echo "Error: package.json not found in the current directory."
+    exit 1
+  fi
+
+  # Check for .node-version file and read version, otherwise use package.json
+  auto_node_version
+
+  # Build if node_modules does not already exist
+  if [[ ! -d node_modules ]]; then
+      # Install dependencies with Yarn or npm based on package.json settings
+      if jq -e '.engines.yarn' package.json >/dev/null; then
+        echo "'engines.yarn' found. Running 'yarn'..."
+        yarn install
+      else
+        echo "'engines.yarn' not found in package.json. Skipping 'yarn' execution."
+        npm install
+      fi
+  fi
+
+  # Run development build, production build or a custom build command based on scripts defined in package.json
+  yarn dj build
+}
+
+# Rebuild the project by removing the lock files and node_modules directory
+djxbuild() {
+  echo "rm -rf yarn.lock package-lock.json node_modules"
+  rm -rf yarn.lock package-lock.json node_modules
+  build
+}
+
+# Check out a branch and then build it
+djcob() {
+  local co_param=$1
+  co "$co_param"
+  djbuild && sayresult
+}
+
+# Check out a branch and then rebuild it
+djcoxb() {
+  local co_param=$1
+  co "$co_param"
+  xbuild && sayresult
+}

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -17,6 +17,8 @@ autoup_minor() {
 
 # Aliases
 alias gl="git log --oneline --graph"
+alias nukejs="rm -rf yarn.lock package-lock.json node_modules && sayresult"
+alias nukephp="rm -rf composer.lock vendor && sayresult"
 
 # Create a new branch and set the origin
 #
@@ -125,3 +127,6 @@ load-node-version-from-package-json() {
 }
 add-zsh-hook chpwd load-node-version-from-package-json
 load-node-version-from-package-json
+
+########################### DJ SCRIPTS ###########################
+source ~/.zshrc-dj.sh


### PR DESCRIPTION
## Changelog
- Add scripts specific to the Dow Jones build process
  - `djbuild` - Build a DJ Plugin or Theme
  - `djxbuild` - Rebuild a DJ Plugin or Theme
  - `djcob` - Check out a branch and build it
  - `djcoxb` - Check out a branch and run a full rebuild
- Add the Nuke scripts
  - `nukejs` - Remove lock files and `node_modules`.
  - `nukephp` - Remove lock files and `vendor`.

---

## How to Test

### Nuke Scripts

1. Check out a repository that has a `vendor` and a `node_modules` directory.
2. Run: `nukejs`.

- [x] Verify that the `yarn.lock` or `package-lock.json` file is removed.
- [x] Verify that the `node_modules directory is removed.
- [ ] Verify that the `sayresult` function fired, notifying you when the process was completed.

3. Run: `nukephp`.

- [x] Verify that the composer.lock file is removed.
- [x] Verify that the `vendor` directory is removed. 
- [x] Verify that the `sayresult` function fired, notifying you when the process was completed.


### Dow Jones Scripts

```
<redacted>
```