### PR TITLE
Adding helper functions for NewsGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+- Adding NewsGrid scripts. 
+
 ## 1.0.0
 - Add README.md file with setup instructions.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ echo 'source ~/dontforgit-config/zshrc.sh' >> ~/.zshrc
 - `djcob` - Check out a branch and build it
 - `djcoxb` - Check out a branch and run a full rebuild
 
+#### NewsGrid Specific Workflows
+- `ngbuild` - Build a NewsGrid Plugin or Theme
+- `ngxbuild` - Rebuild a NewsGrid Plugin or Theme
+
 ### Configurations
 - Autoload the `auto_node_version` function when a new terminal is opened.
 - Setup bash autocompletion

--- a/zshrc-ng.sh
+++ b/zshrc-ng.sh
@@ -1,0 +1,15 @@
+# Build process for NewsPress themes and plugins
+ngbuild() {
+  echo "npm install --legacy-peer-deps"
+  npm install --legacy-peer-deps
+
+  echo "npm run start"
+  npm run start
+}
+
+# Rebuild the project by removing the lock files and node_modules directory
+ngxbuild() {
+  nukejs
+  ngbuild
+  sayresult
+}

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -130,6 +130,7 @@ load-node-version-from-package-json
 
 ########################### DJ SCRIPTS ###########################
 source ~/.zshrc-dj.sh
+source ~/.zshrc-ng.sh
 
 ########################### MISC CONFIGURATIONS ###########################
 # Bash auto-completion


### PR DESCRIPTION
## Changelog
- Adding NewsGrid scripts. 

---

## How to Test
1. In the NewsGrid plugin, run: `ngxbuild`

- [x] Verify that the app removes the `node_modules` folder and does a complete rebuild.

2. Run: `ngbuild`

- [x] Verify that the app rebuilds the plugin and starts the dev server. 